### PR TITLE
Enable GitHub Pages so the site is viewable online

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -1,0 +1,30 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/configure-pages@v5
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: .
+      - id: deployment
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/deploy-pages.yml`: deploys the static site to GitHub Pages on every push to `main`
- Adds `.nojekyll`: tells GitHub Pages to skip Jekyll processing and serve raw HTML/CSS directly

## After merging

1. Go to **Settings → Pages** in this repo and confirm the source is set to **GitHub Actions**
2. The deploy workflow will run automatically and publish the site
3. Your site will be live at: `https://modernuser.github.io/skills-introduction-to-github/`

## Test plan

- [ ] Merge this PR
- [ ] Confirm the `Deploy to GitHub Pages` Action completes successfully
- [ ] Open the Pages URL and verify the Wolf of Fairhope Avenue landing page loads

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019jNKbo5R4nTT1C7zcbHiv5

---
_Generated by [Claude Code](https://claude.ai/code/session_019jNKbo5R4nTT1C7zcbHiv5)_