### PR TITLE
Fix GitHub Pages deployment (auto-enable Pages)

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -23,6 +23,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: actions/configure-pages@v5
+        with:
+          enablement: true
       - uses: actions/upload-pages-artifact@v3
         with:
           path: .


### PR DESCRIPTION
## Problem

The deploy workflow was failing with:
> `Get Pages site failed. Please verify that the repository has Pages enabled`

GitHub Pages was not enabled in repo settings, so `actions/configure-pages` had nothing to connect to.

## Fix

Added `enablement: true` to the `configure-pages` step — this tells the action to automatically enable GitHub Pages with the GitHub Actions source if it isn't already set up.

## After merging

The deploy workflow will re-run automatically. Once it succeeds, the site will be live at:
`https://modernuser.github.io/skills-introduction-to-github/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019jNKbo5R4nTT1C7zcbHiv5

---
_Generated by [Claude Code](https://claude.ai/code/session_019jNKbo5R4nTT1C7zcbHiv5)_