### PR TITLE
Fix GitHub Pages deployment (remove enablement: true)

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -23,8 +23,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: actions/configure-pages@v5
-        with:
-          enablement: true
       - uses: actions/upload-pages-artifact@v3
         with:
           path: .


### PR DESCRIPTION
## Problem

The deploy workflow was failing because `enablement: true` on `configure-pages` tries to create a new Pages site via the GitHub API, but the `GITHUB_TOKEN` in Actions does not have permission to do this (`Resource not accessible`).

## Fix

Removed `enablement: true` from `.github/workflows/deploy-pages.yml`. Pages source must be set once manually in **Settings → Pages → Source: GitHub Actions**, after which the workflow deploys successfully on every push to `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_019jNKbo5R4nTT1C7zcbHiv5)_